### PR TITLE
🐣 [46기 조혜진] Home 화면에 EventCard 컴포넌트 추가

### DIFF
--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -23,6 +23,8 @@ export const S = {
     flex-direction: column;
     gap: 20px;
     padding: 30px;
+    width: fit-content;
+    margin: auto;
   `,
 
   SectionTitle: styled.p`
@@ -34,12 +36,13 @@ export const S = {
     display: flex;
     gap: 28px;
     justify-content: center;
+    width: fit-content;
   `,
 
   CategoryBox: styled.div`
     position: relative;
-    max-width: 320px;
-    min-width: 320px;
+    max-width: 300px;
+    min-width: 300px;
     aspect-ratio: 16/9;
     border-radius: 10px;
     background-image: url(${props => props.src});

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import EventCard from '../../components/EventCard/EventCard.jsx';
 import { S } from './Home';
 
 const Home = () => {
@@ -21,6 +22,11 @@ const Home = () => {
       </S.SectionWrapper>
       <S.SectionWrapper>
         <S.SectionTitle>지금 인기있는 이벤트</S.SectionTitle>
+        <S.BoxWrapper>
+          {EVENTS.map(data => {
+            return <EventCard type="home" key={data.id} data={data} />;
+          })}
+        </S.BoxWrapper>
       </S.SectionWrapper>
       <S.Banner src="./images/Home/banner-sub.jpg" ratio="3/1">
         <S.TextSub>Donation</S.TextSub>
@@ -36,4 +42,35 @@ const CATEGORIES = [
   { id: 2, title: '콘서트', src: './images/Home/category-concert.jpg' },
   { id: 3, title: '퍼포먼스', src: './images/Home/category-performance.jpg' },
   { id: 4, title: '클래식', src: './images/Home/category-classical.jpg' },
+];
+
+const EVENTS = [
+  {
+    id: 37,
+    title: 'Electric Picnic',
+    image:
+      'https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-37.jpg?raw=true',
+    token: 100,
+    description: 'Jul 02, 2023',
+
+    location: '컨벤션',
+  },
+  {
+    id: 55,
+    title: 'The Beautiful Trauma World Tour',
+    image:
+      'https://github.com/HaeJungg/project-image/blob/master/p2-Images/Concert/concert-15.jpg?raw=true',
+    token: 150,
+    description: 'Jul 16, 2023',
+    location: '고척 스카이돔',
+  },
+  {
+    id: 78,
+    title: 'Cinderella',
+    image:
+      'https://github.com/HaeJungg/project-image/blob/master/p2-Images/Performance/performance-18.jpg?raw=true',
+    token: 200,
+    description: 'Jul 23, 2023',
+    location: '오페라하우스',
+  },
 ];


### PR DESCRIPTION
# 🌱 What’s Changing

- Home 화면에 EventCard 공용 컴포넌트를 적용했습니다.
	- 상수데이터로 관리

# 👀 How It Works
- 지금 인기있는 이벤트 카드 목록을 볼 수 있습니다.

# 💡 What I Learned
-  다른 화면에서 쓰이는 컴포넌트를 재사용했습니다. 다른 팀원이 만든 컴포넌트여서 셋팅된 key 값에 맞게 상수데이터를 구성하고 props를 전달했습니다.

# ✅ Screenshot
<img width="1435" alt="Screenshot 2023-06-20 at 12 30 25" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/658f9382-9470-467b-b1c6-492e74c62831">
