### PR TITLE
🐣 [46기 조혜진] 마이페이지에 낙찰 수락 대기 리스트 UI 추가

### DIFF
--- a/public/data/biddingSuccessful.json
+++ b/public/data/biddingSuccessful.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": 1,
+    "title": "Seoul Jazz Festival",
+    "date": "Jul 28, 2023",
+    "location": "서울 송파구 올림픽공원",
+    "price": 500
+  },
+
+  {
+    "id": 2,
+    "title": "Bali Jazz Festival",
+    "date": "Aug 21, 2023",
+    "location": "Canggu Deus Ex Machina",
+    "price": 1000
+  },
+
+  {
+    "id": 31,
+    "title": "Sydney Jazz Festival",
+    "date": "Jun 16, 2024",
+    "location": "Opera House",
+    "price": 800
+  }
+]

--- a/src/components/My/My.js
+++ b/src/components/My/My.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { MdGridView, MdAccountCircle } from 'react-icons/md';
 import { LuDatabase, LuTicket } from 'react-icons/lu';
+import { Mixin } from '../../styles/mixin';
 
 export const M = {
   Text: styled.div`
@@ -15,15 +16,18 @@ export const M = {
     justify-content: flex-end;
   `,
 
-  CTABtn: styled.button`
-    display: flex;
-    padding: 10px 30px;
+  CTABtn: styled.div`
+    ${Mixin.flexCenter};
+    padding: 5px 20px;
     height: 40px;
-    font-size: 20px;
+    font-size: 18px;
     font-weight: 600;
     color: ${props => props.theme.black};
     background-color: ${props => props.theme.kultureGreen};
     border-radius: 10px;
+    &:hover {
+      cursor: pointer;
+    }
   `,
 
   LearnMoreBtn: styled.img`

--- a/src/pages/MyDashboard/MyDashboard.js
+++ b/src/pages/MyDashboard/MyDashboard.js
@@ -3,6 +3,22 @@ import { MdAlarmOn, MdCheckCircleOutline, MdBlock } from 'react-icons/md';
 import { Mixin } from '../../styles/mixin';
 
 export const S = {
+  EmptyBox: styled.div`
+    ${Mixin.flexCenter};
+    padding: 30px;
+    font-size: 18px;
+    font-weight: 400;
+    color: ${props => props.theme.lightGrey};
+    border-radius: 10px;
+    background-color: ${props => props.theme.darkGrey};
+  `,
+
+  TextUnit: styled.div`
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+  `,
+
   AuctionBoxWrapper: styled.div`
     ${Mixin.flexCenter};
     gap: 18px;
@@ -16,7 +32,7 @@ export const S = {
     flex-direction: column;
     gap: 15px;
     width: 290px;
-    height: 210px;
+    height: 180px;
   `,
 
   AuctionBoxDone: styled.div`
@@ -24,7 +40,7 @@ export const S = {
     flex-direction: column;
     gap: 15px;
     width: 290px;
-    height: 210px;
+    height: 180px;
     margin: 10px 0;
     border: 3px solid ${props => props.theme.kultureGreen};
     border-radius: 10px;
@@ -36,7 +52,7 @@ export const S = {
     flex-direction: column;
     gap: 15px;
     width: 290px;
-    height: 210px;
+    height: 180px;
   `,
 
   StatusBox: styled.div`
@@ -61,10 +77,20 @@ export const S = {
     color: ${props => props.theme.lightGrey};
   `,
 
-  TextUnit: styled.div`
+  SuccessBoxWrapper: styled.div`
     display: flex;
-    align-items: baseline;
-    gap: 5px;
+    flex-direction: column;
+    gap: 10px;
+    width: 930px;
+  `,
+
+  SuccessBox: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 10px;
+    padding: 10px 30px;
+    background-color: ${props => props.theme.darkGrey};
   `,
 
   TokenDonationWrapper: styled.div`
@@ -81,7 +107,7 @@ export const S = {
     flex-direction: column;
     gap: 25px;
     width: 450px;
-    height: 250px;
+    height: 200px;
     padding-left: 60px;
     border-radius: 10px;
     border: 3px solid ${props => props.theme.kultureGreen};
@@ -91,13 +117,14 @@ export const S = {
     display: flex;
     align-items: center;
     gap: ${props => props.gap};
+    width: ${props => props.width};
   `,
 
   DonationBox: styled.div`
     ${Mixin.flexCenter}
     gap: 10px;
     width: 450px;
-    height: 250px;
+    height: 200px;
     padding: 0 70px;
     border-radius: 10px;
     background-color: ${props => props.theme.darkGrey};

--- a/src/pages/MyDashboard/MyDashboard.jsx
+++ b/src/pages/MyDashboard/MyDashboard.jsx
@@ -10,6 +10,7 @@ import { S } from './MyDashboard';
 const MyDashboard = () => {
   const navigate = useNavigate();
   const [ticketList, setTicketList] = useState([]);
+  const [successList, setSuccessList] = useState([]);
 
   //ticketList Mock Data
   useEffect(() => {
@@ -19,6 +20,17 @@ const MyDashboard = () => {
         setTicketList(data.list);
       });
   }, []);
+
+  //biddingSuccessful Mock Data
+  useEffect(() => {
+    fetch('data/biddingSuccessful.json')
+      .then(res => res.json())
+      .then(data => {
+        setSuccessList(data);
+      });
+  }, []);
+
+  console.log(successList);
 
   return (
     <>
@@ -41,13 +53,13 @@ const MyDashboard = () => {
             <S.AuctionBoxWrapper>
               <S.AuctionBoxIP>
                 <S.StatusBox>
-                  <M.Text size="18px" weight="500">
+                  <M.Text size="16px" weight="500">
                     입찰 진행 중
                   </M.Text>
                   <S.AuctionIP />
                 </S.StatusBox>
                 <S.TextUnit>
-                  <M.Text size="100px" weight="600">
+                  <M.Text size="70px" weight="600">
                     8
                   </M.Text>
                   <M.Text size="20px" weight="500">
@@ -57,13 +69,13 @@ const MyDashboard = () => {
               </S.AuctionBoxIP>
               <S.AuctionBoxDone>
                 <S.StatusBox>
-                  <M.Text size="18px" weight="500" col="kultureGreen">
+                  <M.Text size="16px" weight="500" col="kultureGreen">
                     낙찰 성공
                   </M.Text>
                   <S.AuctionDone />
                 </S.StatusBox>
                 <S.TextUnit>
-                  <M.Text size="100px" weight="600" col="kultureGreen">
+                  <M.Text size="70px" weight="600" col="kultureGreen">
                     17
                   </M.Text>
                   <M.Text size="20px" weight="500" col="kultureGreen">
@@ -73,13 +85,13 @@ const MyDashboard = () => {
               </S.AuctionBoxDone>
               <S.AuctionBoxFail>
                 <S.StatusBox>
-                  <M.Text size="18px" weight="500" col="lightGrey">
+                  <M.Text size="16px" weight="500" col="lightGrey">
                     낙찰 실패
                   </M.Text>
                   <S.AuctionFail />
                 </S.StatusBox>
                 <S.TextUnit>
-                  <M.Text size="100px" weight="600" col="lightGrey">
+                  <M.Text size="70px" weight="600" col="lightGrey">
                     2
                   </M.Text>
                   <M.Text size="20px" weight="500" col="lightGrey">
@@ -88,6 +100,41 @@ const MyDashboard = () => {
                 </S.TextUnit>
               </S.AuctionBoxFail>
             </S.AuctionBoxWrapper>
+          </M.SectionWrapper>
+
+          <M.SectionWrapper>
+            <M.SectionTitleWrapper>
+              <M.Text size="22px" weight="600">
+                낙찰 수락 대기
+              </M.Text>
+            </M.SectionTitleWrapper>
+            <S.SuccessBoxWrapper>
+              {successList.length === 0 ? (
+                <S.EmptyBox>낙찰 수락 대기중인 이벤트가 없어요!</S.EmptyBox>
+              ) : (
+                successList.map(({ id, title, date, location, price }) => {
+                  return (
+                    <S.SuccessBox key={id}>
+                      <M.Text size="18px" weight="500" width="220px;">
+                        {title}
+                      </M.Text>
+                      <M.Text size="16px" weight="400" width="300px">
+                        {date} ・ {location}
+                      </M.Text>
+
+                      <S.TokenUnit gap="5px" width="80px">
+                        <T.Token src={tokenImg} size="20px" />
+                        <M.Text size="18px" weight="600">
+                          {price.toLocaleString()}
+                        </M.Text>
+                      </S.TokenUnit>
+
+                      <M.CTABtn>구매 확정하기</M.CTABtn>
+                    </S.SuccessBox>
+                  );
+                })
+              )}
+            </S.SuccessBoxWrapper>
           </M.SectionWrapper>
 
           <S.TokenDonationWrapper>
@@ -139,23 +186,27 @@ const MyDashboard = () => {
             </M.SectionTitleWrapper>
 
             <S.TicketBoxWrapper>
-              {ticketList.map(
-                ({ id, name, image_url, location, event_start_date }) => {
-                  return (
-                    <S.TicketBox key={id}>
-                      <S.TicketImage src={image_url} />
-                      <S.TicketInfo>
-                        <M.Text size="22px" weight="500">
-                          {name}
-                        </M.Text>
-                        <M.Text size="16px" weight="400">
-                          {event_start_date} ・ {location}
-                        </M.Text>
-                      </S.TicketInfo>
-                      <M.CTABtn>티켓 확인하기</M.CTABtn>
-                    </S.TicketBox>
-                  );
-                }
+              {ticketList.length === 0 ? (
+                <S.EmptyBox>유효한 티켓이 없어요!</S.EmptyBox>
+              ) : (
+                ticketList.map(
+                  ({ id, name, image_url, location, event_start_date }) => {
+                    return (
+                      <S.TicketBox key={id}>
+                        <S.TicketImage src={image_url} />
+                        <S.TicketInfo>
+                          <M.Text size="22px" weight="500">
+                            {name}
+                          </M.Text>
+                          <M.Text size="16px" weight="400">
+                            {event_start_date} ・ {location}
+                          </M.Text>
+                        </S.TicketInfo>
+                        <M.CTABtn>티켓 확인하기</M.CTABtn>
+                      </S.TicketBox>
+                    );
+                  }
+                )
               )}
             </S.TicketBoxWrapper>
           </M.SectionWrapper>

--- a/src/pages/MyToken/MyToken.js
+++ b/src/pages/MyToken/MyToken.js
@@ -48,9 +48,23 @@ export const S = {
     margin-bottom: 20px;
   `,
 
+  AlertDiv: styled.div`
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    height: 30px;
+  `,
+
+  ZeroAlert: styled.div`
+    display: ${props => (props.status ? 'none' : 'flex')};
+    color: ${props => props.theme.kultureGreen};
+    font-size: 16px;
+    font-weight: 400;
+  `,
+
   Divider: styled.hr`
     border: 1px solid ${props => props.theme.kultureGreen};
-    margin: 40px 0;
+    margin-bottom: 20px;
   `,
 
   OptionBoxWrapper: styled.div`

--- a/src/pages/MyToken/MyToken.jsx
+++ b/src/pages/MyToken/MyToken.jsx
@@ -54,6 +54,11 @@ const MyToken = () => {
                   </M.Text>
                 </S.TokenUnit>
               </S.LineUnit>
+              <S.AlertDiv>
+                <S.ZeroAlert status={chargeAmount !== 0}>
+                  *아래에서 옵션을 선택해주세요.
+                </S.ZeroAlert>
+              </S.AlertDiv>
               <S.Divider />
               <S.LineUnit>
                 <M.Text size="22px" weight="600">


### PR DESCRIPTION
# 🌱 What’s Changing
- 마이페이지 [대시보드] 메뉴 화면에 낙찰 수락(구매 확정) 대기중인 이벤트 리스트 UI가 추가되었습니다.
	

# 🤡 How It Works
- 로그인한 유저의 구매 확정 대기중인 이벤트 리스트를 보여줍니다.
	- 현재 낙찰 수락 대기중인 이벤트가 없을 경우 낙찰 수락 대기중인 이벤트가 없다는 문구를 보여줍니다.

# 💡 What I Learned
- 기존에 만들어 둔 스타일드 컴포넌트를 재사용했습니다.
- 조건부 렌더링을 활용했습니다.

# 🐾 Screenshot
<img width="1149" alt="Screenshot 2023-06-22 at 14 59 48" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/6d62226f-ebb3-4ef8-aefb-d779f40309ba">

<img width="1042" alt="Screenshot 2023-06-22 at 15 34 23" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/b42ab50b-33e2-41bf-9b7b-a5217a4bdac0">