### PR TITLE
# 🐣 [46기 조혜진] 티켓 QR코드 모달창 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/user-event": "^13.5.0",
         "chart.js": "^4.3.0",
         "google-map-react": "^2.2.1",
+        "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
         "react-calendar": "^4.3.0",
         "react-chartjs-2": "^5.2.0",
@@ -14304,6 +14305,14 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@testing-library/user-event": "^13.5.0",
     "chart.js": "^4.3.0",
     "google-map-react": "^2.2.1",
+    "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-calendar": "^4.3.0",
     "react-chartjs-2": "^5.2.0",

--- a/src/components/TicketModal/TicketModal.js
+++ b/src/components/TicketModal/TicketModal.js
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { Mixin } from '../../styles/mixin';
+import { MdClear } from 'react-icons/md';
+
+export const S = {
+  Backdrop: styled.div`
+    ${Mixin.flexCenter}
+    z-index:1;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    backdrop-filter: blur(5px);
+  `,
+
+  Modal: styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    padding: 80px 50px 50px 50px;
+    width: fit-content;
+    background-color: ${props => props.theme.kultureBackground};
+    border: 4px solid ${props => props.theme.kultureGreen};
+    border-radius: 10px;
+  `,
+
+  ExitBtn: styled(MdClear)`
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    font-size: 30px;
+    color: ${props => props.theme.kultureGreen};
+    &:hover {
+      cursor: pointer;
+      filter: brightness(70%);
+    }
+  `,
+
+  Text: styled.p`
+    font-size: 16px;
+    color: ${props => props.theme.white};
+  `,
+};

--- a/src/components/TicketModal/TicketModal.jsx
+++ b/src/components/TicketModal/TicketModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
+import { S } from './TicketModal';
+
+const TicketModal = ({ setIsModalOpen }) => {
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    document.body.style.overflow = 'unset';
+  };
+
+  return (
+    <S.Backdrop>
+      <S.Modal>
+        <S.ExitBtn onClick={handleCloseModal} />
+        <QRCodeCanvas
+          id="qrCode"
+          value="www.google.com"
+          size="150"
+          bgColor="transparent"
+          fgColor="#97FE67"
+          level="H"
+        />
+        <S.Text>*이벤트 현장 매표소에서 본 QR코드를 제시해주세요.</S.Text>
+      </S.Modal>
+    </S.Backdrop>
+  );
+};
+
+export default TicketModal;

--- a/src/pages/MyDashboard/MyDashboard.jsx
+++ b/src/pages/MyDashboard/MyDashboard.jsx
@@ -7,12 +7,18 @@ import learnMoreIcon from '../../images/learn-more.png';
 import { M } from '../../components/My/My';
 import { T } from '../../components/Token';
 import { S } from './MyDashboard';
+import TicketModal from '../../components/TicketModal/TicketModal.jsx';
 
 const MyDashboard = () => {
   const navigate = useNavigate();
   const [userInfo, setUserInfo] = useState({});
   const [successList, setSuccessList] = useState([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [ticketList, setTicketList] = useState([]);
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+    document.body.style.overflow = 'hidden';
+  };
 
   useEffect(() => {
     fetch(`${APIS.users}`, {
@@ -225,7 +231,12 @@ const MyDashboard = () => {
                             {event_start_date} ・ {location}
                           </M.Text>
                         </S.TicketInfo>
-                        <M.CTABtn>티켓 확인하기</M.CTABtn>
+                        <M.CTABtn onClick={handleOpenModal}>
+                          티켓 확인하기
+                        </M.CTABtn>
+                        {isModalOpen ? (
+                          <TicketModal setIsModalOpen={setIsModalOpen} />
+                        ) : null}
                       </S.TicketBox>
                     );
                   }


### PR DESCRIPTION
# 🌱 What’s Changing
- 마이페이지 [대시보드] 메뉴 화면에서 [티켓 확인하기] 버튼 클릭시 QR코드 모달창을 띄웁니다.
	

# 🎃 How It Works
- 해당 이벤트의 QR코드 티켓을 확인할 수 있습니다.
- QR코드 모달창이 띄워져있을 때 배경 스크롤은 막혀 있습니다.
- 모달창의 X 버튼 클릭시 모달창이 닫힙니다.

# 💡 What I Learned
- qrcode.react 라이브러리를 활용했습니다. 라이브러리에서 제공하는 QR코드 컴포넌트에 props로 설정값을 전달하여 원하는 스타일을 적용했습니다. 

# 🎫 Screenshot
<img width="857" alt="Screenshot 2023-06-23 at 1 37 13" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/521a8667-ca01-4bc5-b9c6-5144f822c186">

