### PR TITLE
🐣 [46기 조혜진] 입찰 내역 조회 기능 구현

### DIFF
--- a/public/data/bidList.json
+++ b/public/data/bidList.json
@@ -8,7 +8,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 2,
     "bidding_events_token": 100,
-    "bid_status_code": "BID_PENDING"
+    "bid_status_code": "BID_PENDING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -20,7 +21,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 3,
     "bidding_events_token": 200,
-    "bid_status_code": "BID_PENDING"
+    "bid_status_code": "BID_PENDING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -32,7 +34,8 @@
     "auction_end_date": "Jun 22, 2023",
     "quantity": 2,
     "bidding_events_token": 600,
-    "bid_status_code": "BID_PENDING"
+    "bid_status_code": "BID_PENDING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
   {
     "bidId": 4,
@@ -43,7 +46,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 1,
     "bidding_events_token": 500,
-    "bid_status_code": "BID_LOSING"
+    "bid_status_code": "BID_LOSING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -55,7 +59,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 3,
     "bidding_events_token": 200,
-    "bid_status_code": "BID_LOSING"
+    "bid_status_code": "BID_LOSING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -67,7 +72,8 @@
     "auction_end_date": "Jun 22, 2023",
     "quantity": 2,
     "bidding_events_token": 600,
-    "bid_status_code": "BID_LOSING"
+    "bid_status_code": "BID_LOSING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
   {
     "bidId": 7,
@@ -78,7 +84,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 2,
     "bidding_events_token": 200,
-    "bid_status_code": "BID_WINNING"
+    "bid_status_code": "BID_WINNING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -90,7 +97,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 3,
     "bidding_events_token": 200,
-    "bid_status_code": "BID_WINNING"
+    "bid_status_code": "BID_WINNING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -102,7 +110,8 @@
     "auction_end_date": "Jun 22, 2023",
     "quantity": 2,
     "bidding_events_token": 600,
-    "bid_status_code": "BID_WINNING"
+    "bid_status_code": "BID_WINNING",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
   {
     "bidId": 10,
@@ -113,7 +122,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 1,
     "bidding_events_token": 500,
-    "bid_status_code": "BID_ACCEPTED"
+    "bid_status_code": "BID_ACCEPTED",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -125,7 +135,8 @@
     "auction_end_date": "Jun 25, 2023",
     "quantity": 3,
     "bidding_events_token": 200,
-    "bid_status_code": "BID_ACCEPTED"
+    "bid_status_code": "BID_ACCEPTED",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   },
 
   {
@@ -137,6 +148,7 @@
     "auction_end_date": "Jun 22, 2023",
     "quantity": 2,
     "bidding_events_token": 600,
-    "bid_status_code": "BID_ACCEPTED"
+    "bid_status_code": "BID_ACCEPTED",
+    "Image_url": "https://github.com/HaeJungg/project-image/blob/master/p2-Images/Festival/festival-9.jpg?raw=true"
   }
 ]

--- a/src/pages/MyAuction/MyAuction.js
+++ b/src/pages/MyAuction/MyAuction.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Mixin } from '../../styles/mixin';
 
 export const S = {
   AuctionBox: styled.div`
@@ -18,11 +19,111 @@ export const S = {
     align-items: center;
     gap: 5px;
   `,
+  StatusWrapper: styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    height: 45px;
+  `,
+
+  Status: styled.div`
+    ${Mixin.flexCenter}
+    width: 450px;
+    font-size: 16px;
+    font-weight: 500;
+    border-radius: 10px;
+    background-color: ${props => props.theme.darkGrey};
+    border: ${props =>
+      props.selected ? `3px solid ${props.theme.kultureGreen}` : 'none'};
+    &:hover {
+      cursor: pointer;
+    }
+  `,
+
+  KeyWrapper: styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: ${props => props.gap};
+    margin-top: 15px;
+    padding-right: 45px;
+  `,
+
+  DataKey: styled.div`
+    ${Mixin.flexCenter}
+    font-size: 14px;
+    font-weight: 400;
+    color: ${props => props.theme.lightGrey};
+  `,
 
   HistoryBoxWrapper: styled.div`
     display: flex;
     flex-direction: column;
     gap: 10px;
     width: 930px;
+  `,
+
+  HistoryBox: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 30px;
+    border-radius: 10px;
+    background-color: ${props => props.theme.darkGrey};
+  `,
+
+  EventImg: styled.div`
+    width: 120px;
+    aspect-ratio: 16/9;
+    border-radius: 7px;
+    background-image: url(${props => props.src});
+    background-size: 100%;
+  `,
+
+  EventInfoUnit: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 300px;
+  `,
+
+  EventName: styled.div`
+    font-size: 18px;
+    font-weight: 500;
+  `,
+
+  DateLocation: styled.div`
+    font-size: 16px;
+    font-weight: 400;
+  `,
+
+  Quantity: styled.div`
+    ${Mixin.flexCenter}
+    font-size: 18px;
+    font-weight: 500;
+    width: 100px;
+  `,
+
+  TokenUnit: styled.div`
+    ${Mixin.flexCenter}
+    gap: ${props => props.gap};
+    width: ${props => props.width};
+  `,
+
+  EndDate: styled.div`
+    ${Mixin.flexCenter}
+    font-size: 16px;
+    font-weight: 400;
+    width: 100px;
+  `,
+
+  BidResult: styled.div`
+    ${Mixin.flexCenter}
+    font-size: 18px;
+    font-weight: 600;
+    width: 80px;
+    color: ${props =>
+      props.success
+        ? `${props.theme.kultureGreen}`
+        : `${props.theme.lightGrey}`};
   `,
 };

--- a/src/pages/MyAuction/MyAuction.jsx
+++ b/src/pages/MyAuction/MyAuction.jsx
@@ -1,9 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import My from '../../components/My/My.jsx';
+import tokenImg from '../../images/kulture-token.png';
+import { APIS } from '../../config.js';
 import { M } from '../../components/My/My';
+import { T } from '../../components/Token.js';
 import { S } from './MyAuction';
 
 const MyAuction = () => {
+  const [isIP, setIsIP] = useState(true);
+  const [bidList, setBidList] = useState([]);
+
+  useEffect(() => {
+    fetch(`${APIS.bid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: localStorage.getItem('accessToken'),
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        console.log(data);
+        setBidList(data);
+      });
+  }, []);
+
+  // bidList Mock Data
+  // useEffect(() => {
+  //   fetch('data/bidList.json')
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       setBidList(data);
+  //     });
+  // }, []);
+
   return (
     <>
       <M.Title>내 입찰내역</M.Title>
@@ -12,12 +42,128 @@ const MyAuction = () => {
         <My />
         <M.MainContainer>
           <M.SectionWrapper>
-            <M.Text size="22px" weight="600">
-              내역
-            </M.Text>
-            <S.HistoryBoxWrapper>
-              <M.EmptyBox>아직 입찰내역이 없어요!</M.EmptyBox>
-            </S.HistoryBoxWrapper>
+            <S.StatusWrapper>
+              <S.Status
+                selected={isIP}
+                onClick={() => {
+                  setIsIP(!isIP);
+                }}
+              >
+                입찰 진행 중
+              </S.Status>
+              <S.Status
+                selected={!isIP}
+                onClick={() => {
+                  setIsIP(!isIP);
+                }}
+              >
+                종료
+              </S.Status>
+            </S.StatusWrapper>
+            {isIP ? (
+              <>
+                <S.KeyWrapper gap="83px">
+                  {IP_KEYS.map(({ id, title }) => {
+                    return <S.DataKey key={id}>{title}</S.DataKey>;
+                  })}
+                </S.KeyWrapper>
+                <S.HistoryBoxWrapper>
+                  {bidList.map(
+                    ({
+                      bidId,
+                      name,
+                      location,
+                      event_start_date,
+                      Image_url,
+                      auction_end_date,
+                      quantity,
+                      bid_status_code,
+                      bidding_events_token,
+                    }) => {
+                      if (bid_status_code !== 'BID_PENDING') {
+                        return null;
+                      } else
+                        return (
+                          <S.HistoryBox key={bidId}>
+                            <S.EventImg src={Image_url} />
+                            <S.EventInfoUnit>
+                              <S.EventName>{name}</S.EventName>
+                              <S.DateLocation>
+                                {location} ・ {event_start_date}
+                              </S.DateLocation>
+                            </S.EventInfoUnit>
+                            <S.Quantity>{quantity}</S.Quantity>
+                            <S.TokenUnit gap="5px" width="100px">
+                              <T.Token src={tokenImg} size="20px" />
+                              <M.Text size="18px" weight="600">
+                                {(
+                                  quantity * bidding_events_token
+                                ).toLocaleString()}
+                              </M.Text>
+                            </S.TokenUnit>
+                            <S.EndDate>{auction_end_date}</S.EndDate>
+                          </S.HistoryBox>
+                        );
+                    }
+                  )}
+                </S.HistoryBoxWrapper>
+              </>
+            ) : (
+              <>
+                <S.KeyWrapper gap="53px">
+                  {ENDED_KEYS.map(({ id, title }) => {
+                    return <S.DataKey key={id}>{title}</S.DataKey>;
+                  })}
+                </S.KeyWrapper>
+                <S.HistoryBoxWrapper>
+                  {bidList.map(
+                    ({
+                      bidId,
+                      name,
+                      location,
+                      event_start_date,
+                      Image_url,
+                      auction_end_date,
+                      quantity,
+                      bid_status_code,
+                      bidding_events_token,
+                    }) => {
+                      if (bid_status_code === 'BID_PENDING') {
+                        return null;
+                      } else
+                        return (
+                          <S.HistoryBox key={bidId}>
+                            <S.EventImg src={Image_url} />
+                            <S.EventInfoUnit>
+                              <S.EventName>{name}</S.EventName>
+                              <S.DateLocation>
+                                {location} ・ {event_start_date}
+                              </S.DateLocation>
+                            </S.EventInfoUnit>
+                            <S.Quantity>{quantity}</S.Quantity>
+                            <S.TokenUnit gap="5px" width="100px">
+                              <T.Token src={tokenImg} size="20px" />
+                              <M.Text size="18px" weight="600">
+                                {(
+                                  quantity * bidding_events_token
+                                ).toLocaleString()}
+                              </M.Text>
+                            </S.TokenUnit>
+                            <S.EndDate>{auction_end_date}</S.EndDate>
+                            <S.BidResult
+                              success={bid_status_code !== 'BID_LOSING'}
+                            >
+                              {bid_status_code !== 'BID_LOSING'
+                                ? '성공'
+                                : '실패'}
+                            </S.BidResult>
+                          </S.HistoryBox>
+                        );
+                    }
+                  )}
+                </S.HistoryBoxWrapper>
+              </>
+            )}
           </M.SectionWrapper>
         </M.MainContainer>
       </M.Container>
@@ -26,3 +172,16 @@ const MyAuction = () => {
 };
 
 export default MyAuction;
+
+const IP_KEYS = [
+  { id: 1, title: '입찰 매수' },
+  { id: 2, title: '입찰 총액' },
+  { id: 3, title: '경매 종료일' },
+];
+
+const ENDED_KEYS = [
+  { id: 1, title: '입찰 매수' },
+  { id: 2, title: '입찰 총액' },
+  { id: 3, title: '경매 종료일' },
+  { id: 4, title: '낙찰 여부' },
+];

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -19,7 +19,7 @@ a, dl, dt, dd, ol, ul, li, form, label, table{
 }
 body{
     line-height: 1;
-    color: #FFFFFF;
+    color: #ebebeb;
     background-color: #1C1B1B;
     font-family: 'Pretendard';
 }

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,8 +1,8 @@
 const theme = {
   kultureGreen: '#97FE67',
   kultureBackground: '#1C1B1B',
-  white: '#FFFFFF',
-  black: '#000000',
+  white: '#ebebeb',
+  black: '#1d1d1f',
   lightGrey: '#424242',
   darkGrey: '#282727',
 };


### PR DESCRIPTION
# 🌱 What’s Changing
- 입찰 내역 리스트를 확인할 수 있는 페이지가 추가되었습니다.
	
# 🎃 How It Works
- 로그인한 유저가 마이페이지 [내 입찰내역] 메뉴 화면에서 입찰 내역을 확인할 수 있습니다.
	- 입찰 내역을 입찰 진행 중 / 종료 탭으로 구분하여 보여줍니다.
- 입찰 종료 탭에서 입찰에 성공한 비딩은 '성공', 실패한 비딩은 '실패'로 표시해 줍니다.

# 💡 What I Learned
- Boolean 값을 props로 전달해 컴포넌트의 스타일을 변경할 수 있었습니다.
- Array.map() 메서드 활용시 원하는 element들만 선택적으로 UI가 그려지도록 데이터 key를 활용해 조건을 걸어주었습니다.

# 👀 Screenshot
<img width="1552" alt="Screenshot 2023-06-24 at 19 02 04" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/558f6be9-9ca2-46ab-85e4-c5a00cf6a372">

<img width="1552" alt="Screenshot 2023-06-24 at 19 02 16" src="https://github.com/wecode-bootcamp-korea/46-2nd-Kulture-frontend/assets/123653529/7c7ade42-6b5f-43eb-9137-e74f16637840">
